### PR TITLE
Add session date/time editing

### DIFF
--- a/src/components/EditClimbDialog.tsx
+++ b/src/components/EditClimbDialog.tsx
@@ -27,7 +27,9 @@ const EditClimbDialog = ({ climb, open, onOpenChange, onSave }: EditClimbDialogP
     effort: climb.effort || "",
     notes: climb.notes || "",
     physicalSkills: climb.physicalSkills || [],
-    technicalSkills: climb.technicalSkills || []
+    technicalSkills: climb.technicalSkills || [],
+    timestampDate: climb.timestamp.toISOString().split("T")[0],
+    timestampTime: climb.timestamp.toTimeString().slice(0, 5)
   });
 
   const handleSave = () => {
@@ -41,7 +43,15 @@ const EditClimbDialog = ({ climb, open, onOpenChange, onSave }: EditClimbDialogP
       effort: formData.effort ? Number(formData.effort) : undefined,
       notes: formData.notes || undefined,
       physicalSkills: formData.physicalSkills.length > 0 ? formData.physicalSkills : undefined,
-      technicalSkills: formData.technicalSkills.length > 0 ? formData.technicalSkills : undefined
+      technicalSkills: formData.technicalSkills.length > 0 ? formData.technicalSkills : undefined,
+      timestamp: (() => {
+        const [year, month, day] = formData.timestampDate.split('-').map(Number);
+        const [hours, minutes] = formData.timestampTime.split(':').map(Number);
+        const ts = new Date(climb.timestamp);
+        ts.setFullYear(year, month - 1, day);
+        ts.setHours(hours, minutes, 0, 0);
+        return ts;
+      })()
     };
 
     onSave(climb.id, updates);
@@ -74,6 +84,27 @@ const EditClimbDialog = ({ climb, open, onOpenChange, onSave }: EditClimbDialogP
               onChange={(e) => setFormData(prev => ({ ...prev, grade: e.target.value }))}
               placeholder="5.10a, V4, etc."
             />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label htmlFor="timestampDate">Date</Label>
+              <Input
+                id="timestampDate"
+                type="date"
+                value={formData.timestampDate}
+                onChange={(e) => setFormData(prev => ({ ...prev, timestampDate: e.target.value }))}
+              />
+            </div>
+            <div>
+              <Label htmlFor="timestampTime">Time</Label>
+              <Input
+                id="timestampTime"
+                type="time"
+                value={formData.timestampTime}
+                onChange={(e) => setFormData(prev => ({ ...prev, timestampTime: e.target.value }))}
+              />
+            </div>
           </div>
 
           <div>

--- a/src/components/EditSessionDialog.tsx
+++ b/src/components/EditSessionDialog.tsx
@@ -16,16 +16,27 @@ interface EditSessionDialogProps {
 }
 
 const EditSessionDialog = ({ session, open, onOpenChange, onSave }: EditSessionDialogProps) => {
+  const formatDate = (d: Date) => d.toISOString().split('T')[0];
+  const formatTime = (d: Date) => d.toISOString().slice(11, 16);
+
   const [formData, setFormData] = useState({
     location: session.location,
     climbingType: session.climbingType,
+    date: formatDate(session.startTime),
+    startTime: formatTime(session.startTime),
+    endTime: session.endTime ? formatTime(session.endTime) : "",
     notes: session.notes || ""
   });
 
   const handleSave = () => {
+    const start = new Date(`${formData.date}T${formData.startTime}`);
+    const end = formData.endTime ? new Date(`${formData.date}T${formData.endTime}`) : undefined;
+
     const updates: Partial<Session> = {
       location: formData.location,
       climbingType: formData.climbingType as Session['climbingType'],
+      startTime: start,
+      endTime: end,
       notes: formData.notes || undefined
     };
 
@@ -53,8 +64,8 @@ const EditSessionDialog = ({ session, open, onOpenChange, onSave }: EditSessionD
 
           <div>
             <Label>Climbing Type</Label>
-            <Select 
-              value={formData.climbingType} 
+            <Select
+              value={formData.climbingType}
               onValueChange={(value) => setFormData(prev => ({ ...prev, climbingType: value as Session['climbingType'] }))}
             >
               <SelectTrigger>
@@ -68,6 +79,37 @@ const EditSessionDialog = ({ session, open, onOpenChange, onSave }: EditSessionD
                 <SelectItem value="multipitch">Multi-pitch</SelectItem>
               </SelectContent>
             </Select>
+          </div>
+
+          <div>
+            <Label htmlFor="date">Date</Label>
+            <Input
+              id="date"
+              type="date"
+              value={formData.date}
+              onChange={(e) => setFormData(prev => ({ ...prev, date: e.target.value }))}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <Label htmlFor="startTime">Start Time</Label>
+              <Input
+                id="startTime"
+                type="time"
+                value={formData.startTime}
+                onChange={(e) => setFormData(prev => ({ ...prev, startTime: e.target.value }))}
+              />
+            </div>
+            <div>
+              <Label htmlFor="endTime">End Time</Label>
+              <Input
+                id="endTime"
+                type="time"
+                value={formData.endTime}
+                onChange={(e) => setFormData(prev => ({ ...prev, endTime: e.target.value }))}
+              />
+            </div>
           </div>
 
           <div>

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -185,9 +185,15 @@ const History = () => {
   };
 
   const handleSaveSession = (sessionId: string, updates: Partial<Session>) => {
+    const normalizedUpdates = {
+      ...updates,
+      startTime: updates.startTime ? new Date(updates.startTime) : undefined,
+      endTime: updates.endTime ? new Date(updates.endTime) : undefined
+    };
+
     const updatedSessions = sessions.map(session => session.id === sessionId ? {
       ...session,
-      ...updates
+      ...normalizedUpdates
     } : session);
     setSessions(updatedSessions);
     localStorage.setItem('sessions', JSON.stringify(updatedSessions));
@@ -196,7 +202,7 @@ const History = () => {
     if (selectedSession?.id === sessionId) {
       setSelectedSession(prev => prev ? {
         ...prev,
-        ...updates
+        ...normalizedUpdates
       } : null);
     }
     toast({


### PR DESCRIPTION
## Summary
- allow editing session date and times
- handle normalized time updates when saving sessions

## Testing
- `npm run lint` *(fails: no-empty-object-type etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841f36dfa1083319d60a36916e52b8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the session editing dialog to allow users to separately select and edit the session date, start time, and end time with dedicated input fields.
  - Added date and time inputs to the climb editing dialog for precise timestamp editing.

- **Bug Fixes**
  - Improved handling of session date and time updates to ensure accurate saving and display of session information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->