### PR TITLE
Use env var for OpenRouter default key

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment variables
+
+The app reads a default OpenRouter API key from the `OPENROUTER_API_KEY` environment variable. If this variable is not set, a demo key bundled with the source will be used.

--- a/src/config/openrouter.ts
+++ b/src/config/openrouter.ts
@@ -1,8 +1,10 @@
 
+const envApiKey = process.env.OPENROUTER_API_KEY;
+
 export const OPENROUTER_CONFIG = {
   baseURL: 'https://openrouter.ai/api/v1',
   defaultModel: 'microsoft/phi-4-reasoning-plus:free',
-  defaultApiKey: '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',
+  defaultApiKey: envApiKey ?? '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',
   availableModels: [
     { id: 'microsoft/phi-4-reasoning-plus:free', name: 'Microsoft Phi-4 Reasoning Plus', description: 'Free reasoning model' },
     { id: 'openai/gpt-4o-mini', name: 'GPT-4O Mini', description: 'Fast and affordable' },


### PR DESCRIPTION
## Summary
- load default OpenRouter API key from `process.env.OPENROUTER_API_KEY`
- document new environment variable in README

## Testing
- `npm run lint` *(fails: 6 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68425fb1025483319965aeb586c9a592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to include information about configuring the OpenRouter API key using an environment variable.

- **New Features**
  - The application now supports using an environment variable for the OpenRouter API key, with a fallback to a default key if not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->