### PR TITLE
Remove defunct Goal interface

### DIFF
--- a/src/types/climbing.ts
+++ b/src/types/climbing.ts
@@ -77,25 +77,3 @@ export interface LocalClimb {
   technicalSkills?: string[];
 }
 
-export interface Goal {
-  id: string;
-  user_id: string;
-  title: string;
-  description?: string;
-  type: string;
-  status: 'active' | 'completed' | 'paused';
-  priority: 'low' | 'medium' | 'high';
-  difficulty: 'easy' | 'moderate' | 'hard';
-  target_value?: number;
-  current_value?: number;
-  target_date?: string;
-  completed_at?: string;
-  created_at: string;
-  updated_at: string;
-  notes?: string;
-  tags?: string[];
-  unit?: string;
-  target_grade?: string;
-  target_climb_type?: string;
-  target_location?: string;
-}


### PR DESCRIPTION
## Summary
- delete the unused `Goal` interface from `climbing.ts`

## Testing
- `npm run build`
- `npm run lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68425ff834e0833185161acbbf019eca